### PR TITLE
Fix Travis CI config for macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-
 dist: bionic
 sudo: false
 
@@ -30,7 +22,32 @@ branches:
 matrix:
   include:
     - os: linux
+      language: python
+      python: "2.7"
+
+    - os: linux
+      language: python
+      python: "3.5"
+
+    - os: linux
+      language: python
+      python: "3.6"
+
+    - os: linux
+      language: python
+      python: "3.7"
+
     - os: osx
+      language: shell
+      osx_image: xcode9.2
+
+    - os: osx
+      language: shell
+      osx_image: xcode10.1
+
+    - os: osx
+      language: shell
+      osx_image: xcode11.2
 
   allow_failures:
     - os: osx


### PR DESCRIPTION
On Travis CI, "python: 2.7" is not a valid Python version specification
on macOS; this is documented here:
https://docs.travis-ci.com/user/languages/python/
> Python builds are not available on the macOS environment.

and:

> 'language: python' is an error on Travis CI macOS

Using it as we do on Linux fails as follows:
https://travis-ci.org/mbrukman/csv2txf/jobs/596627885
with an error:

> Unable to download 2.7 archive. The archive may not exist. Please
> consider a different version.

Instead, we need to specify XCode versions which will select the version
of macOS we're using, which will come with a particular version of
Python.