### PR TITLE
Use Ubuntu Bionic (18.04) and only build `master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,12 @@ python:
   - "3.6"
   - "3.7"
 
+dist: bionic
 sudo: false
+
+branches:
+  only:
+    - master
 
 matrix:
   include:


### PR DESCRIPTION
Use the latest Ubuntu version available on Travis CI, which is Bionic
(18.04) at the moment, according to:
https://docs.travis-ci.com/user/reference/overview/
Not specifying a version gets us a much older Xenial (16.04) by default.

By default, Travis CI builds and tests every PR, so any push or
force-push to a PR-designated feature branch results in 2 builds instead
of just one.

This ensures that we only run builds for pushes to `master` and every
feature branch will be automatically taken care of.