### PR TITLE
Replace `float` with `Decimal`

### DIFF
--- a/interactive_brokers.py
+++ b/interactive_brokers.py
@@ -22,6 +22,7 @@ Does not handle:
 
 import csv
 from datetime import datetime
+from decimal import Decimal
 import utils
 
 
@@ -56,7 +57,7 @@ class InteractiveBrokers:
 
     @classmethod
     def ParseDollarValue(cls, value):
-        return float(value.replace(',', '').replace('"', ''))
+        return Decimal(value.replace(',', '').replace('"', ''))
 
     @classmethod
     def isFileForBroker(cls, filename):

--- a/vanguard.py
+++ b/vanguard.py
@@ -28,6 +28,7 @@ __author__ = 'mbrukman@google.com (Misha Brukman)'
 
 import csv
 from datetime import datetime
+from decimal import Decimal
 import utils
 
 
@@ -69,7 +70,7 @@ class Vanguard:
 
     @classmethod
     def netAmount(cls, dict):
-        amount = float(dict['Net Amount'])
+        amount = Decimal(dict['Net Amount'])
         if cls.isBuy(dict):
             return amount * -1
         else:


### PR DESCRIPTION
We should use fixed-decimal for precise representation of fractional quantities
such as dollar amounts rather than floating point values which can be imprecise.