### PR TITLE
Support both `pip` and `pip3` binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,19 +20,20 @@ endif
 test:
 	$(VERB) ./run_all_tests.sh
 
-clean:
-	$(VERB) rm -f `find . -name \*\.pyc`
-
 regen:
 	$(VERB) ./update_testdata.py
 	$(VERB) ./csv2txf_regen.sh
 
 THIRD_PARTY_PYTHON = third_party/python
+PIP := $(shell which pip || which pip3)
 
 install-dev:
-	$(VERB) pip install -r requirements-dev.txt -t $(THIRD_PARTY_PYTHON)
+	$(VERB) $(PIP) install -r requirements-dev.txt -t $(THIRD_PARTY_PYTHON)
 
 # Requires having installed dependencies first via `make install-dev`.
 autopep8:
 	$(VERB) find . -name \*\.py \
 	        | xargs -I {} python $(THIRD_PARTY_PYTHON)/autopep8.py --in-place {}
+
+clean:
+	$(VERB) rm -rf `find . -name \*\.pyc` $(THIRD_PARTY_PYTHON)/*


### PR DESCRIPTION
Also delete all installed third-party Python libraries with `make clean`.