### PR TITLE
Added human-readable summary for CSV inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test:
 
 regen:
 	$(VERB) ./update_testdata.py
+	$(VERB) ./summary_test.sh regen
 	$(VERB) ./csv2txf_regen.sh
 
 THIRD_PARTY_PYTHON = third_party/python

--- a/interactive_brokers.py
+++ b/interactive_brokers.py
@@ -31,6 +31,10 @@ FIRST_LINE = 'Title,Worksheet for Form 8949,'
 
 class InteractiveBrokers:
     @classmethod
+    def name(cls):
+        return 'Interactive Brokers'
+
+    @classmethod
     def DetermineEntryCode(cls, part, box):
         if part == 1:
             if box == 'A':

--- a/summary_test.sh
+++ b/summary_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To regenerate expected stdout in response to changes in the code, run this
+# test with the arg `regen`.
+declare -i regen=0
+if [ "${1:-}" == "regen" ]; then
+  regen=1
+fi
+
+declare -i num_failures=0
+
+# Args:
+#   $0: file with expected stdout
+#   $*: command-line flags for csv2txf.py for this run
+function test_summary() {
+  local expected_out="$1"
+  shift
+
+  if [ $regen -ne 0 ]; then
+    echo "Updating ${expected_out} ..."
+    ./csv2txf.py "$@" > "${expected_out}"
+    return
+  fi
+
+  echo "Testing ${expected_out/.summary.out/} ..."
+  local out="$(mktemp /tmp/csv2txf-summary.out.XXXXXX)"
+  local err="$(mktemp /tmp/csv2txf-summary.err.XXXXXX)"
+  ./csv2txf.py "$@" > "${out}" 2> "${err}"
+
+  diff -u "${expected_out}" "${out}" || {
+    cat "${err}"
+    (( num_failures += 1 ))
+  }
+}
+
+test_summary \
+    testdata/interactive_brokers.summary.out \
+    --broker ib \
+    --file testdata/interactive_brokers.csv \
+    --year 2011 \
+    --outfmt summary
+
+test_summary \
+    testdata/vanguard.summary.out \
+    --broker vanguard \
+    --file testdata/vanguard.csv \
+    --year 2011 \
+    --outfmt summary
+
+if [ ${regen} -eq 0 ]; then
+  if [ ${num_failures} -eq 0 ]; then
+    echo "PASSED"
+  else
+    echo "FAILED"
+    exit 1
+  fi
+fi

--- a/testdata/interactive_brokers.summary.out
+++ b/testdata/interactive_brokers.summary.out
@@ -1,0 +1,5 @@
+Interactive Brokers summary report for 2011
+Num sale txns:  6
+Total cost:     $35416.08
+Total proceeds: $29999.06
+Net gain/loss:  $-5417.02

--- a/testdata/vanguard.summary.out
+++ b/testdata/vanguard.summary.out
@@ -1,0 +1,5 @@
+Vanguard summary report for 2011
+Num sale txns:  2
+Total cost:     $5913.46
+Total proceeds: $7028.76
+Net gain/loss:  $1115.30

--- a/vanguard.py
+++ b/vanguard.py
@@ -37,6 +37,10 @@ FIRST_LINE = ','.join(['"Trade Date"', '"Transaction Type"',
 
 class Vanguard:
     @classmethod
+    def name(cls):
+        return 'Vanguard'
+
+    @classmethod
     def isBuy(cls, dict):
         return dict['Transaction Type'] == 'Buy'
 
@@ -55,7 +59,7 @@ class Vanguard:
         return dict['Symbol']
 
     @classmethod
-    def name(cls, dict):
+    def investmentName(cls, dict):
         return dict['Investment Name']
 
     @classmethod
@@ -113,7 +117,7 @@ class Vanguard:
                 # current buy txn we are processing.
                 assert cls.numShares(buy) == cls.numShares(sell)
                 assert cls.symbol(buy) == cls.symbol(sell)
-                assert cls.name(buy) == cls.name(sell)
+                assert cls.investmentName(buy) == cls.investmentName(sell)
 
                 curr_txn.sellDate = cls.date(sell)
                 curr_txn.sellDateStr = utils.txfDate(curr_txn.sellDate)


### PR DESCRIPTION
This change adds a flag `--outfmt` to `csv2txf.py` which defaults to the value
`txf` to maintain the current behavior of outputting the TXF formatted file
for import to TurboTax.

However, if `--outfmt=summary` is specified to `csv2txf.py` instead, the new
functionality outputs a human-readable summary to be able to easily verify the
transactions at a glance.