### PR TITLE
Add cron config to GitHub Actions to run monthly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,16 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+      #
+      #      ┌───────────── minute (0 - 59)
+      #      │ ┌───────────── hour (0 - 23)
+      #      │ │ ┌───────────── day of the month (1 - 31)
+      #      │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+      #      │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+      #      │ │ │ │ │
+    - cron: '1 2 3 * *'  # run at 2:01 every month on the 3rd day
 
 jobs:
   build:


### PR DESCRIPTION
This will make sure the tests are green even if we're not making regular change sto the code in this repo.