### PR TITLE
Update GitHub Actions to Ubuntu 22.04 and macOS 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,10 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-10.15' ]
-        python: [ '3.6', '3.7', '3.8' ]
+        os: [ 'ubuntu-22.04', 'macos-11' ]
+        python: [ '3.7', '3.8', '3.9' ]
     name: Python ${{ matrix.python }} (${{ matrix.os }})
     steps:
       - name: Checkout repo


### PR DESCRIPTION
The previous versions were quite old, and in the case of macOS 10.15, no longer available, leading to stuck actions are there are no available runners to run the tests:

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Remove Python 3.6 as it is already EOL, and add Python 3.9.
    
Also add `fail-fast: false` to run all tests even if some fail, so we
can get more information about the other tests that will run in
parallel.