### PR TITLE
Remove `#!/usr/bin/python` runline for libraries

### DIFF
--- a/brokers.py
+++ b/brokers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2012 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/interactive_brokers.py
+++ b/interactive_brokers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2012 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tdameritrade.py
+++ b/tdameritrade.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2012 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/vanguard.py
+++ b/vanguard.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2012 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
These are not stand-alone scripts, so they don't need this line, as they are non-executable libraries.