### PR TITLE
Make PyType errors fatal, i.e., fail CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,9 +72,6 @@ jobs:
 
       - name: Check types with PyType
         run: make pytype-test
-        # Mark this check optional for now, in case it starts out failing.
-        # We will make it required once we've fixed any existing issues.
-        continue-on-error: true
         # https://github.com/google/pytype/issues/1475
         #
         # PyType does not yet support Python 3.12 or later; if this step is


### PR DESCRIPTION
Previously, they were optional, with the flag `continue-on-error: true`, which would have the CI succeed even if this check failed. With this change, PyType failing type checking would signal a failure in the CI.