### PR TITLE
Multiple cleanups and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Compiled Python modules
-*.pyc
+__pycache__/
+*.py[cdo]
 
-# Vim temporary files
-*.sw?
+# Temporary editor files
+.*.sw[nop]
+*~

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,6 @@ pytype-test:
 	$(VERB) python -m pytype --python-version=$(PYTHON_VERSION) -k `find . -name 'third_party' -prune -o -name '*.py' -print`
 
 clean:
-	$(VERB) rm -rf `find . -name \*\.pyc` $(THIRD_PARTY_PYTHON)/*
+	$(VERB) rm -rf __pycache__
+	$(VERB) rm -rf `find . -name \*\.pyc`
+	$(VERB) rm -rf $(THIRD_PARTY_PYTHON)/*

--- a/csv2txf.py
+++ b/csv2txf.py
@@ -104,7 +104,7 @@ def main(argv):
         year = int(options.year)
     else:
         year = datetime.today().year - 1
-        utils.Warning(f'Year not specified, defaulting to {year} (last year)\n')
+        utils.Warning(f'Year not specified, defaulting to {year} (last year)')
 
     output = None
     if options.out_format == 'summary':

--- a/csv2txf.py
+++ b/csv2txf.py
@@ -44,13 +44,16 @@ def ConvertTxnListToTxf(txn_list: list[utils.Transaction], tax_year: int, date: 
     lines.append('^')
     for txn in txn_list:
         lines.append('TD')
+        assert txn.entryCode is not None
         lines.append('N%d' % txn.entryCode)
         lines.append('C1')
         lines.append('L1')
         lines.append('P%s' % txn.desc)
         lines.append('D%s' % txn.buyDateStr)
         lines.append('D%s' % txn.sellDateStr)
+        assert txn.costBasis is not None
         lines.append('$%.2f' % txn.costBasis)
+        assert txn.saleProceeds is not None
         lines.append('$%.2f' % txn.saleProceeds)
         if txn.adjustment:
             lines.append('$%.2f' % txn.adjustment)

--- a/interactive_brokers.py
+++ b/interactive_brokers.py
@@ -98,17 +98,16 @@ class InteractiveBrokers(Broker):
                     elif row[1] == 'II':
                         part = 2
                     else:
-                        utils.Warning('unknown part line: "%s"\n' % row)
+                        utils.Warning('unknown part line: "%s"' % row)
                 elif row[0] == 'Box' and len(row) == 3:
                     if row[1] == 'A' or row[1] == 'B' or row[1] == 'C':
                         box = row[1]
                         entry_code = cls.DetermineEntryCode(part, box)
                     else:
-                        utils.Warning('unknown box line: "%s"\n' % row)
+                        utils.Warning('unknown box line: "%s"' % row)
                 elif row[0] == 'Data' and len(row) == 9:
                     if not entry_code:
-                        utils.Warning(
-                            'ignoring data: "%s" as the code is not defined\n')
+                        utils.Warning('ignoring data: "%s" as the code is not defined')
                         continue
                     txn = utils.Transaction()
                     txn.desc = row[1]
@@ -121,12 +120,12 @@ class InteractiveBrokers(Broker):
                         txn.adjustment = cls.ParseDollarValue(row[7])
                     txn.entryCode = entry_code
                     if tax_year and year and year != tax_year:
-                        utils.Warning('ignoring txn: "%s" as the sale is not from %d\n' %
+                        utils.Warning('ignoring txn: "%s" as the sale is not from %d' %
                                       (txn.desc, tax_year))
                     else:
                         txn_list.append(txn)
                     txn = None
                 elif (row[0] != 'Header' and row[0] != 'Footer') or len(row) != 9:
-                    utils.Warning('unknown line: "%s"\n' % row)
+                    utils.Warning('unknown line: "%s"' % row)
 
             return txn_list

--- a/interactive_brokers_test.py
+++ b/interactive_brokers_test.py
@@ -16,7 +16,6 @@
 
 """Tests for interactive_brokers module."""
 
-from datetime import datetime
 import glob
 import os
 import unittest

--- a/tdameritrade.py
+++ b/tdameritrade.py
@@ -139,7 +139,7 @@ class TDAmeritrade(Broker):
                 curr_txn.entryCode = 323  # "LT gain/loss - security"
 
             if tax_year and sellDate.year != tax_year:
-                utils.Warning('ignoring txn: "%s" (line %d) as the sale is not from %d\n' %
+                utils.Warning('ignoring txn: "%s" (line %d) as the sale is not from %d' %
                               (curr_txn.desc, line_num, tax_year))
                 continue
 

--- a/utils.py
+++ b/utils.py
@@ -49,7 +49,7 @@ class UnimplementedError(Error):
 
 
 def Warning(msg: str):
-    sys.stderr.write('warning: %s' % msg)
+    sys.stderr.write('warning: %s\n' % msg)
 
 
 class Transaction:

--- a/utils.py
+++ b/utils.py
@@ -27,6 +27,9 @@ class Error(Exception):
 
 
 class ValueError(Error):
+
+    msg: str
+
     def __init__(self, msg):
         self.msg = msg
 
@@ -35,6 +38,9 @@ class ValueError(Error):
 
 
 class UnimplementedError(Error):
+
+    msg: str
+
     def __init__(self, msg):
         self.msg = msg
 

--- a/vanguard.py
+++ b/vanguard.py
@@ -130,7 +130,7 @@ class Vanguard(Broker):
 
                 buyDate: Optional[datetime] = curr_txn.buyDate
                 if buyDate is None:
-                    utils.Warning(f'Missing buy date for current transaction: {curr_txn}\n')
+                    utils.Warning(f'Missing buy date for current transaction: {curr_txn}')
                     continue
 
                 sellDate: datetime = cls.date(sell)
@@ -144,7 +144,7 @@ class Vanguard(Broker):
 
                 assert sellDate >= buyDate, f'Sell date ({sellDate}) must be on or after buy date ({buyDate})'
                 if tax_year and sellDate.year != tax_year:
-                    utils.Warning('ignoring txn: "%s" as the sale is not from %d\n' %
+                    utils.Warning('ignoring txn: "%s" as the sale is not from %d' %
                                   (curr_txn.desc, tax_year))
                     continue
 

--- a/vanguard.py
+++ b/vanguard.py
@@ -128,7 +128,11 @@ class Vanguard(Broker):
                 assert cls.symbol(buy) == cls.symbol(sell)
                 assert cls.investmentName(buy) == cls.investmentName(sell)
 
-                buyDate: datetime = curr_txn.buyDate
+                buyDate: Optional[datetime] = curr_txn.buyDate
+                if buyDate is None:
+                    utils.Warning(f'Missing buy date for current transaction: {curr_txn}\n')
+                    continue
+
                 sellDate: datetime = cls.date(sell)
                 curr_txn.sellDateStr = utils.txfDate(sellDate)
                 curr_txn.saleProceeds = cls.netAmount(sell)

--- a/vanguard_test.py
+++ b/vanguard_test.py
@@ -16,7 +16,6 @@
 
 """Tests for the vanguard module."""
 
-from datetime import datetime
 import glob
 import os
 import unittest


### PR DESCRIPTION
* Add assertions on txn fields which cannot be None
* Move `\n` from callers into `utils.Warning()`
* Type-annotate optional buy date in vanguard.py
* Add declaration for error class members `msg`
* Remove unused `datetime` imports
* Ignore `__pycache__` in .gitignore